### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-localForage",
-  "main": "angular-localForage.js",
+  "main": "dist/angular-localForage.js",
   "version": "0.2.0",
   "homepage": "https://github.com/ocombe/angular-localForage",
   "authors": [


### PR DESCRIPTION
bower-install points to:

<script src="components/angular-localForage/angular-localForage.js"></script>


which is a 404. This should be dist/angular-localForage.js.
