### PR TITLE
avoiding  attributes from objects before store it on localforage.

### DIFF
--- a/dist/angular-localForage.js
+++ b/dist/angular-localForage.js
@@ -76,6 +76,12 @@
 			var setItem = function(key, value) {
 				var deferred = $q.defer(),
 					args = arguments;
+
+				//avoid $promises attributes from value objects, if is there.
+				if (angular.isObject(value) && angular.isDefined(value.$promise)) {
+					delete value.$promise; //delete attribut from object structure.
+				}
+
 				localforage.setItem(prefix() + key, value).then(function success() {
 					if(notify.setItem) {
 						$rootScope.$broadcast('LocalForageModule.setItem', {key: key, newvalue: value, driver: localforage.driver()});


### PR DESCRIPTION
# issue-13 about avoid $promises attributes before saving an object.

Typically no one should store a $promise (don't make any sense), then I'm just checking if there is a attribute named as $promise, if there is so I delete this attribute of object structure.
