### PR TITLE
feat: Bump localforage dependency to 1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/ocombe/angular-localForage/issues"
   },
   "dependencies": {
-    "localforage": "~1.4"
+    "localforage": "~1.5"
   },
   "devDependencies": {
     "gulp": "~3.9.0",


### PR DESCRIPTION
There are a few things that make 1.5 more desirable over 1.4 - one being this one 
https://github.com/localForage/localForage/pull/633. Then again, 1.5 has one breaking change: https://github.com/localForage/localForage/releases/tag/1.5.0

This affects only the projects that use npm packaging (browserify/webpack)